### PR TITLE
Add backbone unit tests

### DIFF
--- a/tests/test_backbone.py
+++ b/tests/test_backbone.py
@@ -1,6 +1,47 @@
+import sys
+from pathlib import Path
+
 import torch
 
-from models.backbone import CSPDarknetGELAN
+# Ensure the project root is on the import path for the models package
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from models.backbone import (
+    autopad,
+    Conv,
+    GELANBlock,
+    GELAN,
+    CSPDarknetGELAN,
+)
+
+
+def test_autopad():
+    assert autopad(3) == 1
+    assert autopad(5) == 2
+    assert autopad(3, p=0) == 0
+
+
+def test_conv_output_shape():
+    conv = Conv(3, 16, k=3, s=2)
+    x = torch.randn(1, 3, 32, 32)
+    y = conv(x)
+    assert y.shape == (1, 16, 16, 16)
+
+
+def test_gelan_block_shape_and_grad():
+    block = GELANBlock(32)
+    x = torch.randn(2, 32, 64, 64, requires_grad=True)
+    y = block(x)
+    assert y.shape == x.shape
+    y.mean().backward()
+    assert x.grad is not None
+
+
+def test_gelan_stack():
+    gelan = GELAN(16, n=3)
+    x = torch.randn(1, 16, 32, 32)
+    y = gelan(x)
+    assert y.shape == x.shape
 
 
 def test_backbone_output_shapes():


### PR DESCRIPTION
## Summary
- test autopad padding helper
- cover Conv and GELAN block behavior
- verify CSPDarknetGELAN multi-scale outputs and gradient flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892a9394b9483309f4aa53bdf2d85c9