### PR TITLE
Add training utilities and loss functions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,8 +5,8 @@ TODO for yolov9-pytorch
 - ~~[T1] Implement backbone (CSPDarknet + GELAN).~~
 - ~~[T2] Develop PAN-FPN with PGI neck.~~
 - ~~[T3] Build anchor-free detection head.~~
-- [T4] Implement loss functions (Focal + IoU + Classification).
-- [T5] Add training script supporting custom datasets.
+- ~~[T4] Implement loss functions (Focal + IoU + Classification).~~
+- ~~[T5] Add training script supporting custom datasets.~~
 - [T6] Create inference script.
 - [T7] Enable model export to ONNX and TorchScript.
 - [T8] Define project dependencies in requirements.txt.

--- a/yolov9-pytorch/data/__init__.py
+++ b/yolov9-pytorch/data/__init__.py
@@ -1,0 +1,3 @@
+from .coco import COCODataset, collate_fn
+
+__all__ = ["COCODataset", "collate_fn"]

--- a/yolov9-pytorch/data/coco.py
+++ b/yolov9-pytorch/data/coco.py
@@ -1,0 +1,45 @@
+"""COCO dataset helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import torch
+from torch.utils.data import Dataset
+from torchvision.datasets import CocoDetection
+from torchvision import transforms as T
+
+
+class COCODataset(Dataset):
+    """Thin wrapper around :class:`torchvision.datasets.CocoDetection`."""
+
+    def __init__(self, image_dir: str | Path, ann_file: str | Path, img_size: int = 256) -> None:
+        super().__init__()
+        self.coco = CocoDetection(str(image_dir), str(ann_file))
+        self.img_size = img_size
+        self.tf = T.Compose([T.Resize((img_size, img_size)), T.ToTensor()])
+
+    def __len__(self) -> int:  # noqa: D401
+        return len(self.coco)
+
+    def __getitem__(self, idx: int) -> Tuple[torch.Tensor, Dict[str, torch.Tensor]]:  # noqa: D401
+        img, targets = self.coco[idx]
+        img = self.tf(img)
+        boxes: List[List[float]] = []
+        labels: List[int] = []
+        for t in targets:
+            x, y, w, h = t["bbox"]
+            boxes.append([x, y, x + w, y + h])
+            labels.append(t["category_id"])
+        boxes_t = torch.tensor(boxes, dtype=torch.float32) if boxes else torch.zeros((0, 4), dtype=torch.float32)
+        labels_t = torch.tensor(labels, dtype=torch.long) if labels else torch.zeros((0,), dtype=torch.long)
+        return img, {"boxes": boxes_t, "labels": labels_t}
+
+
+def collate_fn(batch: List[Tuple[torch.Tensor, Dict[str, torch.Tensor]]]) -> Tuple[torch.Tensor, List[Dict[str, torch.Tensor]]]:
+    imgs, targets = zip(*batch)
+    return torch.stack(list(imgs)), list(targets)
+
+
+__all__ = ["COCODataset", "collate_fn"]

--- a/yolov9-pytorch/tests/test_losses.py
+++ b/yolov9-pytorch/tests/test_losses.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT / "yolov9-pytorch"))
+
+from utils.losses import FocalLoss, IoULoss  # noqa: E402
+
+
+def test_focal_loss_zero_when_correct():
+    loss_fn = FocalLoss()
+    pred = torch.tensor([10.0, -10.0])
+    target = torch.tensor([1.0, 0.0])
+    loss = loss_fn(pred, target)
+    assert loss.item() < 1e-4
+
+
+def test_iou_loss_basic():
+    loss_fn = IoULoss()
+    box1 = torch.tensor([[0.0, 0.0, 1.0, 1.0]])
+    box2 = torch.tensor([[0.0, 0.0, 1.0, 1.0]])
+    assert torch.isclose(loss_fn(box1, box2), torch.tensor(0.0), atol=1e-6).item()
+    box3 = torch.tensor([[0.0, 0.0, 1.0, 1.0]])
+    box4 = torch.tensor([[0.5, 0.5, 1.5, 1.5]])
+    val = loss_fn(box3, box4).item()
+    assert 0 < val < 1

--- a/yolov9-pytorch/train.py
+++ b/yolov9-pytorch/train.py
@@ -1,0 +1,90 @@
+"""Simple training script for YOLOv9 using COCO annotations."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, List
+
+import torch
+from torch import optim
+from torch.utils.data import DataLoader
+
+from models.yolov9 import YOLOv9
+from utils.losses import YOLOLoss
+from data import COCODataset, collate_fn
+
+
+@torch.no_grad()
+def build_targets(
+    targets: List[Dict[str, torch.Tensor]],
+    preds: List[torch.Tensor],
+    num_classes: int,
+    img_size: int,
+) -> Dict[str, List[torch.Tensor]]:
+    """Map ground truth boxes to model output grids."""
+    strides = [img_size // p.shape[2] for p in preds]
+    device = preds[0].device
+    batch_size = len(targets)
+    cls_t, box_t, mask_t = [], [], []
+    for p, s in zip(preds, strides):
+        _, _, h, w = p.shape
+        cls_t.append(torch.zeros(batch_size, num_classes, h, w, device=device))
+        box_t.append(torch.zeros(batch_size, 4, h, w, device=device))
+        mask_t.append(torch.zeros(batch_size, 1, h, w, device=device))
+    for b, t in enumerate(targets):
+        boxes = t["boxes"] / img_size
+        labels = t["labels"]
+        areas = (boxes[:, 2] - boxes[:, 0]) * (boxes[:, 3] - boxes[:, 1])
+        for box, cls, area in zip(boxes, labels, areas):
+            if area < 0.02:
+                idx = 0
+            elif area < 0.15:
+                idx = 1
+            else:
+                idx = 2
+            h, w = cls_t[idx].shape[2:]
+            cxcy = (box[:2] + box[2:]) / 2
+            ij = (cxcy * torch.tensor([w, h], device=device)).long().clamp(0, h - 1)
+            j, i = ij[1].item(), ij[0].item()
+            mask_t[idx][b, 0, j, i] = 1
+            box_t[idx][b, :, j, i] = box
+            cls_t[idx][b, cls, j, i] = 1
+    return {"cls": cls_t, "box": box_t, "mask": mask_t}
+
+
+def train(args: argparse.Namespace) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = YOLOv9(args.variant, num_classes=args.num_classes).to(device)
+    dataset = COCODataset(args.images, args.annotations, img_size=args.img_size)
+    loader = DataLoader(dataset, batch_size=args.batch, shuffle=True, collate_fn=collate_fn)
+    criterion = YOLOLoss(args.num_classes)
+    optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=0.9)
+    model.train()
+    for epoch in range(args.epochs):
+        for imgs, targets in loader:
+            imgs = imgs.to(device)
+            preds = model(imgs)
+            t = build_targets(targets, preds, args.num_classes, args.img_size)
+            loss = criterion(preds, t)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+        print(f"epoch {epoch + 1}: loss={loss.item():.4f}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train YOLOv9 on a COCO style dataset")
+    parser.add_argument("--images", type=Path, required=True, help="Directory with training images")
+    parser.add_argument("--annotations", type=Path, required=True, help="Path to COCO annotation JSON file")
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch", type=int, default=4)
+    parser.add_argument("--img-size", type=int, default=256)
+    parser.add_argument("--variant", type=str, default="n")
+    parser.add_argument("--num-classes", type=int, default=80)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    train(parse_args())

--- a/yolov9-pytorch/utils/__init__.py
+++ b/yolov9-pytorch/utils/__init__.py
@@ -1,0 +1,3 @@
+from .losses import FocalLoss, IoULoss, ClassificationLoss, YOLOLoss
+
+__all__ = ["FocalLoss", "IoULoss", "ClassificationLoss", "YOLOLoss"]

--- a/yolov9-pytorch/utils/losses.py
+++ b/yolov9-pytorch/utils/losses.py
@@ -1,0 +1,108 @@
+"""Loss functions for YOLOv9 training."""
+
+from __future__ import annotations
+
+from typing import List
+
+import torch
+import torch.nn as nn
+
+
+def box_iou(box1: torch.Tensor, box2: torch.Tensor) -> torch.Tensor:
+    """Compute IoU between two sets of boxes.
+
+    Boxes are expected in ``(x1, y1, x2, y2)`` format.
+    """
+    # Intersection
+    tl = torch.max(box1[:, None, :2], box2[:, :2])
+    br = torch.min(box1[:, None, 2:], box2[:, 2:])
+    inter = (br - tl).clamp(min=0).prod(dim=2)
+    # Areas
+    area1 = (box1[:, 2:] - box1[:, :2]).prod(dim=1)
+    area2 = (box2[:, 2:] - box2[:, :2]).prod(dim=1)
+    union = area1[:, None] + area2 - inter
+    return inter / (union + 1e-7)
+
+
+class IoULoss(nn.Module):
+    """IoU loss returning ``1 - IoU``."""
+
+    def __init__(self, reduction: str = "mean") -> None:
+        super().__init__()
+        self.reduction = reduction
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        iou = box_iou(pred, target)
+        loss = 1.0 - iou
+        if self.reduction == "mean":
+            return loss.mean()
+        if self.reduction == "sum":
+            return loss.sum()
+        return loss
+
+
+class FocalLoss(nn.Module):
+    """Binary focal loss with logits."""
+
+    def __init__(self, alpha: float = 0.25, gamma: float = 2.0, reduction: str = "mean") -> None:
+        super().__init__()
+        self.alpha = alpha
+        self.gamma = gamma
+        self.reduction = reduction
+        self.bce = nn.BCEWithLogitsLoss(reduction="none")
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        bce = self.bce(pred, target)
+        prob = torch.sigmoid(pred)
+        pt = target * prob + (1 - target) * (1 - prob)
+        alpha = target * self.alpha + (1 - target) * (1 - self.alpha)
+        loss = alpha * (1 - pt) ** self.gamma * bce
+        if self.reduction == "mean":
+            return loss.mean()
+        if self.reduction == "sum":
+            return loss.sum()
+        return loss
+
+
+class ClassificationLoss(nn.Module):
+    """Multi-label classification loss using BCE with logits."""
+
+    def __init__(self, reduction: str = "mean") -> None:
+        super().__init__()
+        self.loss = nn.BCEWithLogitsLoss(reduction=reduction)
+
+    def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        return self.loss(pred, target)
+
+
+class YOLOLoss(nn.Module):
+    """Composite loss combining classification focal loss and IoU loss."""
+
+    def __init__(self, num_classes: int, box_weight: float = 1.0, cls_weight: float = 1.0) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.box_weight = box_weight
+        self.cls_weight = cls_weight
+        self.focal = FocalLoss()
+        self.iou = IoULoss()
+
+    def forward(self, preds: List[torch.Tensor], targets: dict) -> torch.Tensor:  # noqa: D401
+        total = torch.tensor(0.0, device=preds[0].device)
+        for p, t_cls, t_box, t_mask in zip(preds, targets["cls"], targets["box"], targets["mask"]):
+            box_pred = p[:, :4]
+            cls_pred = p[:, 4:]
+            mask = t_mask.bool().squeeze(1)
+            if mask.any():
+                box_loss = self.iou(box_pred.permute(0, 2, 3, 1)[mask], t_box.permute(0, 2, 3, 1)[mask])
+                cls_loss = self.focal(cls_pred.permute(0, 2, 3, 1)[mask], t_cls.permute(0, 2, 3, 1)[mask])
+                total = total + self.box_weight * box_loss + self.cls_weight * cls_loss
+        return total
+
+
+__all__ = [
+    "FocalLoss",
+    "IoULoss",
+    "ClassificationLoss",
+    "YOLOLoss",
+    "box_iou",
+]


### PR DESCRIPTION
## Summary
- implement Focal, IoU, classification, and combined YOLO losses
- add COCO dataset wrapper and training script for custom data
- mark completed tasks in TODO and add unit tests for losses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892b71f7f348330be45ad5995cf899b