### PR TITLE
Support YOLOv9 variant set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,3 +4,4 @@
 - Do not modify the paper located in `arXiv-2402.13616v2`.
 - After making changes, run a Python unit tests before finishing, pytest -q
 - Do not copy any of the code or docs from yolov9-org directory, it must be rewritten from scratch.
+- Maintain support for all YOLOv9 variants: t, s, m, c, e.

--- a/TODO.md
+++ b/TODO.md
@@ -12,4 +12,5 @@ TODO for yolov9-pytorch
 - [T8] Define project dependencies in requirements.txt.
 - [T9] Organize project structure (models, utils, data, configs).
 - [T10] Ensure modular architecture for easy customization.
+- ~~[T11] Support model variants (t, s, m, c, e).~~
 

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,19 @@ This project provides a pure PyTorch implementation of YOLOv9, focusing on:
 - Training and inference capabilities
 - Support for custom datasets
 
+## Model Variants
+
+This implementation supports multiple model scales:
+
+- **YOLOv9t** – tiny
+- **YOLOv9s** – small
+- **YOLOv9m** – medium
+- **YOLOv9c** – compact
+- **YOLOv9e** – extended
+
+Choose a variant by passing `variant="t"|"s"|"m"|"c"|"e"` to the
+`YOLOv9` constructor or helper functions.
+
 ### Model Components
 
 ```

--- a/yolov9-pytorch/export.py
+++ b/yolov9-pytorch/export.py
@@ -13,7 +13,7 @@ from models.yolov9 import YOLOv9
 def export_onnx(
     out_path: Path,
     weights: Path | None = None,
-    variant: str = "n",
+    variant: str = "t",
     num_classes: int = 80,
     img_size: int = 256,
 ) -> None:
@@ -39,7 +39,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Export YOLOv9 model to ONNX")
     parser.add_argument("out", type=Path, help="output ONNX file path")
     parser.add_argument("--weights", type=Path, help="optional path to model weights")
-    parser.add_argument("--variant", type=str, default="n")
+    parser.add_argument("--variant", type=str, default="t")
     parser.add_argument("--num-classes", type=int, default=80)
     parser.add_argument("--img-size", type=int, default=256)
     return parser.parse_args()

--- a/yolov9-pytorch/inference.py
+++ b/yolov9-pytorch/inference.py
@@ -37,7 +37,9 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run YOLOv9 inference on an image")
     parser.add_argument("image", type=Path, help="path to the image file")
     parser.add_argument("--weights", type=Path, help="optional path to model weights")
-    parser.add_argument("--variant", type=str, default="n", help="model variant (n/s/m/l)")
+    parser.add_argument(
+        "--variant", type=str, default="t", help="model variant (t/s/m/c/e)"
+    )
     parser.add_argument("--num-classes", type=int, default=80, help="number of model classes")
     parser.add_argument("--img-size", type=int, default=256, help="inference image size")
     return parser.parse_args()

--- a/yolov9-pytorch/models/yolov9.py
+++ b/yolov9-pytorch/models/yolov9.py
@@ -59,13 +59,19 @@ class Detect(nn.Module):
 
 
 class YOLOv9(nn.Module):
-    """Unified YOLOv9 model with configurable variants."""
+    """Unified YOLOv9 model with configurable variants.
+
+    Supported variants are ``t`` (tiny), ``s`` (small), ``m`` (medium),
+    ``c`` (compact) and ``e`` (extended).  The tuple in :data:`VARIANTS`
+    defines ``(base_channels, depth_multiplier)`` for each configuration.
+    """
 
     VARIANTS: Dict[str, Tuple[int, float]] = {
-        "n": (16, 0.33),
+        "t": (16, 0.33),
         "s": (32, 0.33),
         "m": (48, 0.67),
-        "l": (64, 1.0),
+        "c": (64, 1.0),
+        "e": (80, 1.0),
     }
 
     def __init__(self, variant: str = "s", num_classes: int = 80) -> None:
@@ -116,7 +122,7 @@ class YOLOv9(nn.Module):
         else:
             state = ckpt
 
-        mapping = {16: "n", 32: "s", 48: "m", 64: "l"}
+        mapping = {16: "t", 32: "s", 48: "m", 64: "c", 80: "e"}
         ch0 = None
         if "backbone.stem.conv.weight" in state:
             ch0 = state["backbone.stem.conv.weight"].shape[0]

--- a/yolov9-pytorch/tests/test_inference.py
+++ b/yolov9-pytorch/tests/test_inference.py
@@ -17,7 +17,7 @@ def test_inference_pipeline(tmp_path):
     img.save(img_path)
     tensor = load_image(img_path, 256)
     assert tensor.shape == (1, 3, 256, 256)
-    model = YOLOv9("n", num_classes=80)
+    model = YOLOv9("t", num_classes=80)
     preds = run_inference(model, tensor)
     assert len(preds) == 3
     assert preds[0].shape == (1, 84, 32, 32)

--- a/yolov9-pytorch/tests/test_model.py
+++ b/yolov9-pytorch/tests/test_model.py
@@ -14,7 +14,7 @@ from models.yolov9 import YOLOv9
 
 
 def test_forward_shapes():
-    model = YOLOv9("n", num_classes=80)
+    model = YOLOv9("t", num_classes=80)
     x = torch.randn(1, 3, 256, 256)
     outputs = model(x)
     assert len(outputs) == 3
@@ -44,10 +44,10 @@ def test_pretrained_loading():
 
 
 def test_from_pretrained_roundtrip(tmp_path):
-    model = YOLOv9("n", num_classes=80)
+    model = YOLOv9("t", num_classes=80)
     weight_file = tmp_path / "weights.pt"
     torch.save(model.state_dict(), weight_file)
-    loaded = YOLOv9.from_pretrained(str(weight_file), variant="n", num_classes=80)
+    loaded = YOLOv9.from_pretrained(str(weight_file), variant="t", num_classes=80)
 
     # ensure all parameters are identical
     for k, v in model.state_dict().items():
@@ -61,7 +61,7 @@ def test_from_pretrained_roundtrip(tmp_path):
 
 
 def test_from_pretrained_variant_mismatch(tmp_path):
-    model = YOLOv9("n", num_classes=80)
+    model = YOLOv9("t", num_classes=80)
     weight_file = tmp_path / "weights.pt"
     torch.save(model.state_dict(), weight_file)
     with pytest.raises(ValueError, match="variant"):
@@ -69,8 +69,8 @@ def test_from_pretrained_variant_mismatch(tmp_path):
 
 
 def test_from_pretrained_class_mismatch(tmp_path):
-    model = YOLOv9("n", num_classes=80)
+    model = YOLOv9("t", num_classes=80)
     weight_file = tmp_path / "weights.pt"
     torch.save(model.state_dict(), weight_file)
     with pytest.raises(ValueError, match="classes"):
-        YOLOv9.from_pretrained(str(weight_file), variant="n", num_classes=42)
+        YOLOv9.from_pretrained(str(weight_file), variant="t", num_classes=42)

--- a/yolov9-pytorch/train.py
+++ b/yolov9-pytorch/train.py
@@ -114,7 +114,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--epochs", type=int, default=1)
     parser.add_argument("--batch", type=int, default=4)
     parser.add_argument("--img-size", type=int, default=256)
-    parser.add_argument("--variant", type=str, default="n")
+    parser.add_argument("--variant", type=str, default="t")
     parser.add_argument("--num-classes", type=int, default=80)
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument(


### PR DESCRIPTION
## Summary
- Support YOLOv9t/s/m/c/e variants in the model and weight loader
- Default export, inference and training scripts to variant `t`
- Document variant support and update agent and TODO guidelines

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c554518c8330bbaac67bff328315