### PR TITLE
docs: add detailed comments for models and losses

### DIFF
--- a/yolov9-pytorch/models/backbone.py
+++ b/yolov9-pytorch/models/backbone.py
@@ -1,10 +1,17 @@
-"""Backbone modules for YOLO PyTorch project.
+"""Backbone modules for the custom YOLOv9 implementation.
 
-This module implements a minimal CSPDarknet backbone enhanced with GELAN
-(Generalized Efficient Layer Aggregation Network) blocks.  The
-implementation is intentionally lightweight but follows the high level
-architecture described in the YOLOv9 paper: a Darknet style network with
-Cross Stage Partial (CSP) connections and GELAN blocks.
+The aim of this file is to provide a small, easy to read recreation of the
+backbone described in the `YOLOv9` paper.  It borrows the overall layout of a
+`CSPDarknet` network and enhances the core blocks with *GELAN* (Generalized
+Efficient Layer Aggregation Network) style aggregation.  Only a subset of the
+original architecture is implemented but the main ideas are preserved:
+
+* use simple Conv→BN→SiLU blocks throughout
+* aggregate features with GELAN blocks
+* expose feature maps at strides 8, 16 and 32 for the detection head
+
+The code is intentionally compact so the comments below explain the reasoning
+behind each step in detail.
 """
 
 from __future__ import annotations
@@ -16,34 +23,65 @@ import torch.nn as nn
 
 
 def autopad(k: int, p: int | None = None) -> int:
-    """Compute padding size automatically."""
+    """Compute padding size automatically.
+
+    When no explicit padding ``p`` is provided we default to ``k // 2``.  This
+    emulates the behaviour of ``padding='same'`` which keeps spatial
+    dimensions constant for odd ``k``.  The helper mirrors the logic used in
+    the reference implementation and keeps layer definitions concise.
+    """
+
     return k // 2 if p is None else p
 
 
 class Conv(nn.Module):
-    """A standard convolution layer: Conv2d -> BatchNorm -> SiLU."""
+    """Convolutional block used throughout the model.
+
+    The block performs a 2D convolution followed by batch normalisation and a
+    ``SiLU`` activation.  This mirrors the conv blocks employed by the official
+    implementation and avoids repeating the pattern in every module.
+
+    Args:
+        c1: Number of input channels.
+        c2: Number of output channels.
+        k: Convolution kernel size.
+        s: Stride of the convolution.
+        p: Optional explicit padding.  When ``None`` the :func:`autopad`
+            helper is used to emulate ``padding='same'`` behaviour.
+        groups: Convolution groups for grouped convolutions.
+    """
 
     def __init__(self, c1: int, c2: int, k: int = 1, s: int = 1, p: int | None = None, groups: int = 1) -> None:
         super().__init__()
+        # ``bias=False`` is standard practice when BatchNorm is used as it
+        # already provides a learnable bias term.
         self.conv = nn.Conv2d(c1, c2, k, s, autopad(k, p), groups=groups, bias=False)
         self.bn = nn.BatchNorm2d(c2)
         self.act = nn.SiLU()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        """Apply the Conv→BN→SiLU sequence to the input tensor."""
+
         return self.act(self.bn(self.conv(x)))
 
 
 class GELANBlock(nn.Module):
-    """GELAN block consisting of two convolutional branches.
+    """Minimal GELAN block with two aggregation branches.
 
-    Each branch performs a 1x1 reduction followed by a 3x3 convolution.
-    The outputs of the branches are aggregated together with the input and
-    passed through an activation function, mimicking the behaviour of the
-    Generalized Efficient Layer Aggregation Network described in YOLOv9.
+    The block reproduces the aggregation principle of GELAN/E-ELAN from the
+    paper: the input tensor is processed by two parallel branches.  Each branch
+    first reduces the number of channels with a ``1×1`` convolution and then
+    expands features with a ``3×3`` convolution.  Their outputs are added to the
+    original input (residual connection) and passed through a final normalisation
+    and activation step.  The design promotes feature reuse while keeping the
+    number of parameters small.
     """
 
     def __init__(self, channels: int) -> None:
         super().__init__()
+        # The hidden dimension controls the bottleneck size.  A ``max`` guard is
+        # used to avoid creating zero-width layers when ``channels`` is tiny
+        # (e.g. in the ``t`` variant).
         hidden = max(channels // 2, 1)
         self.branch1 = nn.Sequential(Conv(channels, hidden, 1), Conv(hidden, channels, 3))
         self.branch2 = nn.Sequential(Conv(channels, hidden, 1), Conv(hidden, channels, 3))
@@ -51,30 +89,47 @@ class GELANBlock(nn.Module):
         self.act = nn.SiLU()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        """Return aggregated features from both branches and the shortcut."""
+
+        # Process the input through the two branches.
         y1 = self.branch1(x)
         y2 = self.branch2(x)
+        # Combine branch outputs with the original input and apply BN + SiLU.
         return self.act(self.bn(x + y1 + y2))
 
 
 class GELAN(nn.Module):
-    """Stack of :class:`GELANBlock` layers."""
+    """A simple container stacking multiple :class:`GELANBlock` objects."""
 
     def __init__(self, channels: int, n: int = 1) -> None:
         super().__init__()
+        # ``n`` controls the depth of the block stack.  In the official models
+        # the number of repetitions grows with the model scale; here we mimic
+        # that behaviour via ``depth_multiplier`` in :class:`CSPDarknetGELAN`.
         self.blocks = nn.Sequential(*[GELANBlock(channels) for _ in range(n)])
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:  # noqa: D401
+        """Apply all stacked GELAN blocks sequentially."""
+
         return self.blocks(x)
 
 
 class CSPDarknetGELAN(nn.Module):
-    """CSPDarknet backbone with GELAN blocks.
+    """CSPDarknet backbone augmented with GELAN blocks.
 
-    The backbone width (``base_channels``) and depth (``depth_multiplier``)
-    can be adjusted to create the various model scales (nano, small, etc.).
-    The network returns three feature maps corresponding to strides 8, 16
-    and 32 relative to the input resolution.  It is purposely simplified
-    but captures the essence of the original YOLOv9 backbone.
+    The original YOLOv9 backbone uses a combination of CSP connections and
+    GELAN/E-ELAN blocks to efficiently scale depth and width.  This condensed
+    version keeps the same spirit: four sequential stages progressively reduce
+    spatial resolution while increasing channel capacity.  The network exposes
+    the outputs of the last three stages which correspond to strides ``8``,
+    ``16`` and ``32`` relative to the input and are consumed by the detection
+    head.
+
+    Args:
+        base_channels: Number of channels in the first stage.  Larger values
+            yield wider networks.
+        depth_multiplier: Scales the number of GELAN blocks per stage, allowing
+            the creation of tiny through large variants using the same code.
     """
 
     def __init__(self, base_channels: int = 32, depth_multiplier: float = 1.0) -> None:
@@ -83,9 +138,14 @@ class CSPDarknetGELAN(nn.Module):
 
         def d(n: int) -> int:
             """Round ``n`` based on ``depth_multiplier`` ensuring at least 1."""
+
             return max(int(round(n * depth_multiplier)), 1)
 
+        # Stem: initial downsampling from RGB input.
         self.stem = Conv(3, c, k=3, s=2)
+
+        # Each stage halves the spatial dimensions (stride 2) and expands the
+        # channel width.  A stack of GELAN blocks then refines the features.
         self.stage1 = nn.Sequential(Conv(c, c * 2, k=3, s=2), GELAN(c * 2, n=d(1)))
         self.stage2 = nn.Sequential(Conv(c * 2, c * 4, k=3, s=2), GELAN(c * 4, n=d(2)))
         self.stage3 = nn.Sequential(Conv(c * 4, c * 8, k=3, s=2), GELAN(c * 8, n=d(3)))
@@ -101,6 +161,7 @@ class CSPDarknetGELAN(nn.Module):
             list[torch.Tensor]: Feature maps at strides 8, 16 and 32.
         """
 
+        # ``p3``/``p4``/``p5`` naming follows the FPN convention.
         x = self.stem(x)
         x = self.stage1(x)
         p3 = self.stage2(x)

--- a/yolov9-pytorch/models/yolov9.py
+++ b/yolov9-pytorch/models/yolov9.py
@@ -1,4 +1,10 @@
-"""YOLOv9 detection model implemented from scratch."""
+"""YOLOv9 detection model implemented from scratch.
+
+Only the core architectural pieces required for inference are reproduced in
+this project.  The goal is not to be feature complete but to provide a clear
+and well commented PyTorch implementation that mirrors the design presented in
+the paper and in the reference code base.
+"""
 
 from __future__ import annotations
 
@@ -14,52 +20,93 @@ from .backbone import CSPDarknetGELAN, Conv
 
 
 class PANFPN(nn.Module):
-    """Simple PAN-style feature pyramid network.
+    """Simplified PANet/FPN neck used to fuse multi-scale features.
 
-    It performs a top-down and bottom-up pass using :class:`Conv` blocks.
-    The implementation is intentionally lightweight but sufficient for
-    loading pretrained weights and running basic inference tests.
+    The network performs a top-down pathway followed by a bottom-up pathway,
+    closely resembling the structure described in the YOLOv9 paper.  Each
+    lateral or smoothing operation is implemented with the shared
+    :class:`~yolov9_pytorch.models.backbone.Conv` block for consistency.
+    Despite its compact form this neck is sufficient for loading official
+    checkpoints and validating predictions.
     """
 
     def __init__(self, base_channels: int) -> None:
         super().__init__()
+        # Channel counts coming from the backbone at strides 8/16/32.
         c3, c4, c5 = base_channels * 4, base_channels * 8, base_channels * 16
-        c_out = base_channels * 4
+        c_out = base_channels * 4  # unified channel width for all pyramid levels
+
+        # Lateral 1×1 convolutions used before upsampling/concatenation.
         self.cv5 = Conv(c5, c_out, 1)
         self.cv4 = Conv(c4, c_out, 1)
         self.cv3 = Conv(c3, c_out, 1)
+
         self.up = nn.Upsample(scale_factor=2, mode="nearest")
+
+        # Smoothing convs applied after concatenation in the top-down pass.
         self.smooth4 = Conv(c_out * 2, c_out, 3)
         self.smooth3 = Conv(c_out * 2, c_out, 3)
+
+        # Bottom-up pass where features are downsampled and merged again.
         self.down4 = Conv(c_out, c_out, 3, s=2)
         self.out4 = Conv(c_out * 2, c_out, 3)
         self.down5 = Conv(c_out, c_out, 3, s=2)
         self.out5 = Conv(c_out * 2, c_out, 3)
 
     def forward(self, feats: List[torch.Tensor]) -> List[torch.Tensor]:  # noqa: D401
+        """Fuse feature maps from the backbone into a pyramid.
+
+        Args:
+            feats: List of tensors ``[p3, p4, p5]`` from the backbone.
+
+        Returns:
+            list[torch.Tensor]: Fused features ``[p3, n4, n5]`` ready for the
+            detection head.
+        """
+
         p3, p4, p5 = feats
+
+        # Top-down pathway: upsample higher level features and concatenate.
         p5 = self.cv5(p5)
         p4 = self.smooth4(torch.cat([self.cv4(p4), self.up(p5)], dim=1))
         p3 = self.smooth3(torch.cat([self.cv3(p3), self.up(p4)], dim=1))
+
+        # Bottom-up pathway: refine by downsampling and merging again.
         n4 = self.out4(torch.cat([self.down4(p3), p4], dim=1))
         n5 = self.out5(torch.cat([self.down5(n4), p5], dim=1))
         return [p3, n4, n5]
 
 
 class Detect(nn.Module):
-    """Detection head predicting bounding boxes and class scores."""
+    """Anchor-free detection head.
+
+    Each feature map is processed by a ``1×1`` convolution that outputs ``nc``
+    class logits and four bounding box coordinates per spatial location.  The
+    head itself performs no post-processing; it simply returns raw predictions
+    for the caller to decode.
+    """
 
     def __init__(self, nc: int, ch: List[int]) -> None:
         super().__init__()
         self.nc = nc
+        # ``ch`` holds the number of channels for each pyramid level; a separate
+        # conv layer is created for every scale.
         self.m = nn.ModuleList([nn.Conv2d(c, nc + 4, 1) for c in ch])
 
     def forward(self, x: List[torch.Tensor]) -> List[torch.Tensor]:  # noqa: D401
+        """Apply the detection conv to each feature map in ``x``."""
+
         return [m(v) for m, v in zip(self.m, x)]
 
 
 class YOLOv9(nn.Module):
     """Unified YOLOv9 model with configurable variants.
+
+    The architecture is composed of three high level parts: a GELAN based
+    backbone (:class:`CSPDarknetGELAN`), a PAN-FPN style neck
+    (:class:`PANFPN`) and a lightweight anchor-free detection head
+    (:class:`Detect`).  Different model scales are obtained by adjusting the
+    base number of channels and depth multiplier as reported in the paper.
 
     Supported variants are ``t`` (tiny), ``s`` (small), ``m`` (medium),
     ``c`` (compact) and ``e`` (extended).  The tuple in :data:`VARIANTS`
@@ -78,30 +125,38 @@ class YOLOv9(nn.Module):
         super().__init__()
         if variant not in self.VARIANTS:
             raise ValueError(f"unknown variant '{variant}'")
+
         base, depth = self.VARIANTS[variant]
         self.variant = variant
+
+        # Build backbone, neck and detection head according to the variant
+        # specific width (`base`) and depth parameters.
         self.backbone = CSPDarknetGELAN(base_channels=base, depth_multiplier=depth)
         self.neck = PANFPN(base)
-        ch = [base * 4] * 3
+        ch = [base * 4] * 3  # channel dimensions for detection layers
         self.detect = Detect(num_classes, ch)
 
     def forward(self, x: torch.Tensor) -> List[torch.Tensor]:  # noqa: D401
+        """Run a forward pass through backbone, neck and detection head."""
+
         feats = self.backbone(x)
         feats = self.neck(feats)
         return self.detect(feats)
 
     @classmethod
     def from_pretrained(cls, weight_path: str, num_classes: int = 80, variant: str | None = None) -> "YOLOv9":
-        """Create model and load weights from a YOLOv9 ``.pt`` checkpoint.
+        """Instantiate a model from a YOLOv9 ``.pt`` checkpoint.
 
-        The method performs a best-effort loading: weights that do not match
-        the current architecture are skipped.  This allows loading official
-        checkpoints even though this implementation is simplified.
+        The original checkpoints were trained with a richer code base.  To keep
+        this implementation lightweight we only load matching parameters and
+        silently skip the rest.  The helper also attempts to infer the model
+        variant from the checkpoint to ensure the architecture matches.
         """
 
         import types
 
         # Allow ``torch.load`` to deserialise the original Ultralytics modules
+        # by providing dummy stand-ins for the missing packages.
         class DummyModule(types.ModuleType):
             def __getattr__(self, name: str):
                 cls = type(name, (nn.Module,), {})
@@ -111,6 +166,8 @@ class YOLOv9(nn.Module):
         for mod in ["models", "models.common", "models.yolo"]:
             sys.modules[mod] = DummyModule(mod)  # type: ignore[assignment]
 
+        # Load checkpoint.  We accept plain state dicts as well as training
+        # checkpoints that store the model inside a dictionary.
         ckpt = torch.load(weight_path, map_location="cpu", weights_only=False)
         if isinstance(ckpt, dict):
             if "model" in ckpt and hasattr(ckpt["model"], "state_dict"):
@@ -122,6 +179,7 @@ class YOLOv9(nn.Module):
         else:
             state = ckpt
 
+        # Infer the variant by inspecting the first conv layer of the backbone.
         mapping = {16: "t", 32: "s", 48: "m", 64: "c", 80: "e"}
         ch0 = None
         if "backbone.stem.conv.weight" in state:
@@ -143,6 +201,7 @@ class YOLOv9(nn.Module):
                 f"checkpoint is for variant '{inferred_variant}' but variant '{variant}' was requested"
             )
 
+        # Validate that the requested number of classes matches the checkpoint.
         nc_ckpt = None
         for key in ("model.24.m.0.weight", "model.23.m.0.weight", "detect.m.0.weight"):
             if key in state:
@@ -153,6 +212,7 @@ class YOLOv9(nn.Module):
                 f"checkpoint has {nc_ckpt} classes but model built for {num_classes}"
             )
 
+        # Build the model and load compatible weights.
         model = cls(variant=variant, num_classes=num_classes)
         own = model.state_dict()
         compatible = {k: v for k, v in state.items() if k in own and own[k].shape == v.shape}


### PR DESCRIPTION
## Summary
- document GELAN-based backbone and its utility functions
- add explanatory comments for PAN/FPN neck, detection head, and model variants
- clarify IoU, focal, and composite YOLO losses with step-by-step notes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892da17c8c483308ae8c573f05797c7